### PR TITLE
✨ Implement right sidebar labelset

### DIFF
--- a/lib/timeline/Timeline.js
+++ b/lib/timeline/Timeline.js
@@ -708,6 +708,7 @@ export default class Timeline extends Core {
     else if (util.hasParent(element, this.timeAxis.dom.foreground))      {what = 'axis';}
     else if (this.timeAxis2 && util.hasParent(element, this.timeAxis2.dom.foreground)) {what = 'axis';}
     else if (util.hasParent(element, this.itemSet.dom.labelSet))         {what = 'group-label';}
+    else if (util.hasParent(element, this.itemSet.dom.rightLabelSet))    {what = 'group-label';}
     else if (util.hasParent(element, this.currentTime.bar))              {what = 'current-time';}
     else if (util.hasParent(element, this.dom.center))                   {what = 'background';}
 

--- a/lib/timeline/component/Group.js
+++ b/lib/timeline/component/Group.js
@@ -77,6 +77,10 @@ class Group {
       label: {
         width: 0,
         height: 0
+      },
+      rightLabel: {
+        width: 0,
+        height: 0
       }
     };
     this.className = null;
@@ -116,10 +120,23 @@ class Group {
     }
     this.dom.label = label;
 
+    const rightLabel = document.createElement('div');
+    if (this.itemSet.options.groupEditable.order) {
+      rightLabel.className = 'vis-label draggable';
+    } else {
+      rightLabel.className = 'vis-label';
+    }
+    this.dom.rightLabel = rightLabel
+
     const inner = document.createElement('div');
     inner.className = 'vis-inner';
     label.appendChild(inner);
     this.dom.inner = inner;
+
+    const rightInner = document.createElement('div');
+    rightInner.className = 'vis-inner';
+    rightLabel.appendChild(rightInner);
+    this.dom.rightInner = rightInner;
 
     const foreground = document.createElement('div');
     foreground.className = 'vis-group';
@@ -151,6 +168,7 @@ class Group {
 
     // update contents
     let content;
+    let rightContent;
     let templateFunction;
 
     if (data && data.subgroupVisibility) {
@@ -162,8 +180,10 @@ class Group {
     if (this.itemSet.options && this.itemSet.options.groupTemplate) {
       templateFunction = this.itemSet.options.groupTemplate.bind(this);
       content = templateFunction(data, this.dom.inner);
+      content = templateFunction(data, this.dom.rightInner);
     } else {
       content = data && data.content;
+      rightContent = data && data.rightContent;
     }
 
     if (content instanceof Element) {
@@ -171,25 +191,41 @@ class Group {
         this.dom.inner.removeChild(this.dom.inner.firstChild);
       }
       this.dom.inner.appendChild(content);
+
+      while (this.dom.rightInner.firstChild) {
+        this.dom.rightInner.removeChild(this.dom.rightInner.firstChild);
+      }
+      this.dom.rightInner.appendChild(rightContent);
     } else if (content instanceof Object && content.isReactComponent) {
       // Do nothing. Component was rendered into the node be ReactDOM.render.
       // That branch is necessary for evasion of a second call templateFunction.
       // Supports only React < 16(due to the asynchronous nature of React 16).
     } else if (content instanceof Object) {
       templateFunction(data, this.dom.inner);
+      templateFunction(data, this.dom.rightInner);
     } else if (content !== undefined && content !== null) {
       this.dom.inner.innerHTML = util.xss(content);
+      this.dom.rightInner.innerHTML = util.xss(rightContent);
     } else {
       this.dom.inner.innerHTML = util.xss(this.groupId || ''); // groupId can be null
+      this.dom.rightInner.innerHTML = util.xss(this.groupId || ''); // groupId can be null
     }
 
     // update title
     this.dom.label.title = data && data.title || '';
+    this.dom.rightLabel.title = data && data.title || '';
     if (!this.dom.inner.firstChild) {
       util.addClassName(this.dom.inner, 'vis-hidden');
     }
     else {
       util.removeClassName(this.dom.inner, 'vis-hidden');
+    }
+
+    if (!this.dom.rightInner.firstChild) {
+      util.addClassName(this.dom.rightInner, 'vis-hidden');
+    }
+    else {
+      util.removeClassName(this.dom.rightInner, 'vis-hidden');
     }
 
     if (data && data.nestedGroups) {
@@ -213,11 +249,24 @@ class Group {
         util.removeClassName(this.dom.label, 'expanded');
         util.addClassName(this.dom.label, 'collapsed');
       }
+
+      util.addClassName(this.dom.rightLabel, 'vis-nesting-group');
+      if (this.showNested) {
+        util.removeClassName(this.dom.rightLabel, 'collapsed');
+        util.addClassName(this.dom.rightLabel, 'expanded');
+      } else {
+        util.removeClassName(this.dom.rightLabel, 'expanded');
+        util.addClassName(this.dom.rightLabel, 'collapsed');
+      }
     } else if (this.nestedGroups) {
       this.nestedGroups = null;
       util.removeClassName(this.dom.label, 'collapsed');
       util.removeClassName(this.dom.label, 'expanded');
       util.removeClassName(this.dom.label, 'vis-nesting-group');
+
+      util.removeClassName(this.dom.rightLabel, 'collapsed');
+      util.removeClassName(this.dom.rightLabel, 'expanded');
+      util.removeClassName(this.dom.rightLabel, 'vis-nesting-group');
     }
 
     if (data && (data.treeLevel|| data.nestedInGroup)) {
@@ -228,8 +277,17 @@ class Group {
         // Nesting level is unknown, but we're sure it's at least 1
         util.addClassName(this.dom.label, 'vis-group-level-unknown-but-gte1');
       }
+
+      util.addClassName(this.dom.rightLabel, 'vis-nested-group');
+      if (data.treeLevel) {
+        util.addClassName(this.dom.rightLabel, 'vis-group-level-' + data.treeLevel);
+      } else {
+        // Nesting level is unknown, but we're sure it's at least 1
+        util.addClassName(this.dom.rightLabel, 'vis-group-level-unknown-but-gte1');
+      }
     } else {
       util.addClassName(this.dom.label, 'vis-group-level-0');
+      util.addClassName(this.dom.rightLabel, 'vis-group-level-0');
     }
     
     // update className
@@ -237,11 +295,13 @@ class Group {
     if (className != this.className) {
       if (this.className) {
         util.removeClassName(this.dom.label, this.className);
+        util.removeClassName(this.dom.rightLabel, this.className);
         util.removeClassName(this.dom.foreground, this.className);
         util.removeClassName(this.dom.background, this.className);
         util.removeClassName(this.dom.axis, this.className);
       }
       util.addClassName(this.dom.label, className);
+      util.addClassName(this.dom.rightLabel, className);
       util.addClassName(this.dom.foreground, className);
       util.addClassName(this.dom.background, className);
       util.addClassName(this.dom.axis, className);
@@ -251,10 +311,12 @@ class Group {
     // update style
     if (this.style) {
       util.removeCssText(this.dom.label, this.style);
+      util.removeCssText(this.dom.rightLabel, this.style);
       this.style = null;
     }
     if (data && data.style) {
       util.addCssText(this.dom.label, data.style);
+      util.addCssText(this.dom.rightLabel, data.style);
       this.style = data.style;
     }
   }
@@ -472,8 +534,12 @@ class Group {
     // recalculate size of label
     const labelWidth = this.dom.inner.clientWidth;
     const labelHeight = this.dom.inner.clientHeight;
+    const rightLabelWidth = this.dom.rightInner.clientWidth;
+    const rightLabelHeight = this.dom.rightInner.clientHeight;
     resized = util.updateProperty(this.props.label, 'width', labelWidth) || resized;
     resized = util.updateProperty(this.props.label, 'height', labelHeight) || resized;
+    resized = util.updateProperty(this.props.rightLabel, 'width', rightLabelWidth) || resized;
+    resized = util.updateProperty(this.props.rightLabel, 'height', rightLabelHeight) || resized;
     return resized;
   }
 
@@ -485,6 +551,7 @@ class Group {
     this.dom.background.style.height = `${height}px`;
     this.dom.foreground.style.height = `${height}px`;
     this.dom.label.style.height = `${height}px`;
+    this.dom.rightLabel.style.height = `${height}px`;
   }
 
   /**
@@ -661,6 +728,10 @@ class Group {
       this.itemSet.dom.labelSet.appendChild(this.dom.label);
     }
 
+    if (!this.dom.rightLabel.parentNode) {
+      this.itemSet.dom.rightLabelSet.appendChild(this.dom.rightLabel);
+    }
+
     if (!this.dom.foreground.parentNode) {
       this.itemSet.dom.foreground.appendChild(this.dom.foreground);
     }
@@ -681,6 +752,11 @@ class Group {
     const label = this.dom.label;
     if (label.parentNode) {
       label.parentNode.removeChild(label);
+    }
+
+    const rightLabel = this.dom.rightLabel;
+    if (rightLabel.parentNode) {
+      rightLabel.parentNode.removeChild(rightLabel);
     }
 
     const foreground = this.dom.foreground;

--- a/lib/timeline/component/ItemSet.js
+++ b/lib/timeline/component/ItemSet.js
@@ -260,6 +260,11 @@ class ItemSet extends Component {
     labelSet.className = 'vis-labelset';
     this.dom.labelSet = labelSet;
 
+    // create right labelset
+    const rightLabelSet = document.createElement('div');
+    rightLabelSet.className = 'vis-labelset';
+    this.dom.rightLabelSet = rightLabelSet;
+
     // create ungrouped Group
     this._updateUngrouped();
 
@@ -573,6 +578,11 @@ class ItemSet extends Component {
     if (this.dom.labelSet.parentNode) {
       this.dom.labelSet.parentNode.removeChild(this.dom.labelSet);
     }
+
+    // remove the right labelset containing all group labels
+    if (this.dom.rightLabelSet.parentNode) {
+      this.dom.rightLabelSet.parentNode.removeChild(this.dom.rightLabelSet);
+    }
   }
 
   /**
@@ -596,6 +606,11 @@ class ItemSet extends Component {
       } else {
         this.body.dom.left.appendChild(this.dom.labelSet);
       }
+    }
+
+    // show labelset containing labels
+    if (!this.dom.rightLabelSet.parentNode) {
+      this.body.dom.right.appendChild(this.dom.rightLabelSet);
     }
   }
 
@@ -984,6 +999,14 @@ class ItemSet extends Component {
    */
   getLabelSet() {
     return this.dom.labelSet;
+  }
+
+  /**
+   * Get the element for the right labelset
+   * @return {HTMLElement} labelSet
+   */
+  getRightLabelSet() {
+    return this.dom.rightLabelSet;
   }
 
   /**

--- a/lib/timeline/component/css/labelset.css
+++ b/lib/timeline/component/css/labelset.css
@@ -36,6 +36,7 @@
 .vis-labelset .vis-label .vis-inner {
   display: inline-block;
   padding: 5px;
+  white-space: nowrap;
 }
 
 .vis-labelset .vis-label .vis-inner.vis-hidden {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -111,6 +111,7 @@ export interface SubGroupVisibilityOptions {
 export interface DataGroup {
   className?: string;
   content: string | HTMLElement;
+  rightContent: string | HTMLElement;
   id: IdType;
   options?: DataGroupOptions;
   style?: string;


### PR DESCRIPTION
## What's changed
Originally, `vis-timeline` allowed to show groups (labels) either on the left or right side. 

This change allows package users to specify an additional group content - the main group content is shown on the left, additional content - respectively on the right side.

## How to show right-side group
Use `rightContent` field, when you compose a group JSON.

:bulb: Hint:
```
export interface DataGroup {
  className?: string;
  -> content: string | HTMLElement;      // SHOWS LEFT-SIDE GROUP
  -> rightContent: string | HTMLElement; // SHOWS RIGHT-SIDE GROUP
  id: IdType;
  options?: DataGroupOptions;
  ........
}
```

---

**Note:**
This is a fast workaround & better data structure/field names might be used. Further changes might be expected.
